### PR TITLE
fix shader split by defines

### DIFF
--- a/src/shader/WGSLParseDefines.ts
+++ b/src/shader/WGSLParseDefines.ts
@@ -137,7 +137,7 @@ function splitShaderStrsByDefine(shader: string, defines: Array<string>): Array<
 		defines?.map((define) => {
 			const length = currentShaderStr.indexOf(define);
 			const sliceStr = currentShaderStr.slice(0, length);
-			currentShaderStr = currentShaderStr.slice(length + 1 + define.length);
+			currentShaderStr = currentShaderStr.slice(length + define.length);
 			return sliceStr;
 		}) || [];
 	if (shaderStrs?.length) shaderStrs.push(currentShaderStr);


### PR DESCRIPTION
用 define 变量 split shader源代码时，去掉额外的 +1， 解决变量名后如果跟了分号，导致生成的shader产生错误，例如下面的代码，替换 `VERTEX_COLOR` 变量，会导致最后的分号被去掉，而产生代码解析错误：

```wgsl
            @fragment
            fn main(
                @location(0) fragPosition: vec4f
            ) -> @location(0) vec4f {
                #if USE_VERTEX_COLOR
                    return VERTEX_COLOR;
                #else
                    return fragPosition;
                #endif
            }
```